### PR TITLE
Add qwant.com in search engines

### DIFF
--- a/src/content-script/search-engine-configs.ts
+++ b/src/content-script/search-engine-configs.ts
@@ -72,4 +72,29 @@ export const config: Record<string, SearchEngine> = {
     sidebarContainerQuery: ['#sidebar_results'],
     appendContainerQuery: [],
   },
+  qwant: {
+    inputQuery: ["[name='q']"],
+    sidebarContainerQuery: ['.is-sidebar'],
+    appendContainerQuery: [],
+    watchRouteChange(callback) {
+      const targetNode = document.querySelector('#root')!
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList') {
+            mutation.addedNodes.forEach(function (node) {
+              if (
+                'className' in node &&
+                typeof node.className === 'string' &&
+                node.className.includes('is-sidebar')
+              ) {
+                callback()
+              }
+            })
+          }
+        }
+      })
+      const config = { attributes: true, childList: true, subtree: true }
+      observer.observe(targetNode, config)
+    },
+  },
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -230,7 +230,8 @@
         "https://*.yandex.uz/search*",
         "https://*.yandex.kz/search*",
         "https://*.yandex.by/search*",
-        "https://searx.be/search*"
+        "https://searx.be/search*",
+        "https://www.qwant.com/*"
       ],
       "js": ["content-script.js"],
       "css": ["content-script.css"]


### PR DESCRIPTION
Qwant is a search engine that was launched in 2013. It is based in France and is designed to provide users with a private and unbiased search experience. Unlike other search engines, Qwant does not track users' search histories or personalize results based on their online behavior.

so I integrated the possibility as for the other engines to have chat-gpt integrated

![chat-gpt in qwant](https://user-images.githubusercontent.com/13977106/213190117-f91f112f-fd98-43ee-9506-7782b487d935.png)
