### PR TITLE
Fix model type #219

### DIFF
--- a/src/background/chatgpt.ts
+++ b/src/background/chatgpt.ts
@@ -50,7 +50,7 @@ export async function sendMessage(params: {
           },
         },
       ],
-      model: 'text-davinci-002-render',
+      model: 'text-davinci-002-render-next',
       parent_message_id: uuidv4(),
     }),
     onMessage(message: string) {


### PR DESCRIPTION
OpenAi chatGPT changed model from ```text-davinci-002-render``` to ```text-davinci-002-render-next```,
When use text-davinci-002-render, it returns ```That model does not exist```

![image](https://user-images.githubusercontent.com/35559153/216251587-5d62f512-dace-484a-9eb1-c06bd35d94cd.png)
