### PR TITLE
Modify locale ko

### DIFF
--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -3,6 +3,6 @@
     "message": "ChatGPT for Google"
   },
   "appDesc": {
-    "message": "ChatGPT의 응답과 검색 엔진 결과를 함께 표시하라"
+    "message": "ChatGPT의 응답과 검색 엔진 결과를 함께 표시합니다"
   }
 }


### PR DESCRIPTION
> Correct grammatically incorrect sentences

The existing sentence is grammatically incorrect and can be interpreted as imperative.  
Therefore, it is corrected to a sentence that is grammatically correct.