### PR TITLE
Add model options for ChatGPT plus

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,7 @@ export async function fetchPromotion(): Promise<PromotionResponse | null> {
 }
 
 export async function fetchExtensionConfigs(): Promise<{
-  chatgpt_webapp_model_name: string
+  chatgpt_webapp_model_names: string[]
   openai_model_names: string[]
 }> {
   return fetch(`${API_HOST}/api/config`, {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -10,7 +10,8 @@ async function generateAnswers(port: Browser.Runtime.Port, question: string) {
   let provider: Provider
   if (providerConfigs.provider === ProviderType.ChatGPT) {
     const token = await getChatGPTAccessToken()
-    provider = new ChatGPTProvider(token)
+    const model = providerConfigs.configs[ProviderType.ChatGPT]!.model
+    provider = new ChatGPTProvider(token, model)
   } else if (providerConfigs.provider === ProviderType.GPT3) {
     const { apiKey, model } = providerConfigs.configs[ProviderType.GPT3]!
     provider = new OpenAIProvider(apiKey, model)

--- a/src/background/providers/chatgpt.ts
+++ b/src/background/providers/chatgpt.ts
@@ -47,8 +47,9 @@ export async function getChatGPTAccessToken(): Promise<string> {
 }
 
 export class ChatGPTProvider implements Provider {
-  constructor(private token: string) {
+  constructor(private token: string, private model: string) {
     this.token = token
+    this.model = model
   }
 
   private async fetchModels(): Promise<
@@ -60,8 +61,7 @@ export class ChatGPTProvider implements Provider {
 
   private async getModelName(): Promise<string> {
     try {
-      const models = await this.fetchModels()
-      return models[0].slug
+      return this.model
     } catch (err) {
       console.error(err)
       return 'text-davinci-002-render'

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,21 +65,30 @@ interface GPT3ProviderConfig {
   apiKey: string
 }
 
+interface ChatGPTProviderConfig {
+  model: string
+}
+
 export interface ProviderConfigs {
   provider: ProviderType
   configs: {
     [ProviderType.GPT3]: GPT3ProviderConfig | undefined
+    [ProviderType.ChatGPT]: ChatGPTProviderConfig | undefined
   }
 }
 
 export async function getProviderConfigs(): Promise<ProviderConfigs> {
   const { provider = ProviderType.ChatGPT } = await Browser.storage.local.get('provider')
-  const configKey = `provider:${ProviderType.GPT3}`
-  const result = await Browser.storage.local.get(configKey)
+  const OpenAIconfigKey = `provider:${ProviderType.GPT3}`
+  const ChatGPTconfigKey = `provider:${ProviderType.ChatGPT}`
+  const OpenAIResult = await Browser.storage.local.get(OpenAIconfigKey)
+  const ChatGPTResult = await Browser.storage.local.get(ChatGPTconfigKey)
+
   return {
     provider,
     configs: {
-      [ProviderType.GPT3]: result[configKey],
+      [ProviderType.GPT3]: OpenAIResult[OpenAIconfigKey],
+      [ProviderType.ChatGPT]: ChatGPTResult[ChatGPTconfigKey],
     },
   }
 }
@@ -91,5 +100,6 @@ export async function saveProviderConfigs(
   return Browser.storage.local.set({
     provider,
     [`provider:${ProviderType.GPT3}`]: configs[ProviderType.GPT3],
+    [`provider:${ProviderType.ChatGPT}`]: configs[ProviderType.ChatGPT],
   })
 }


### PR DESCRIPTION
ChatGPT Plus users can use `text-davinci-002-render-paid` and `text-davinci-002-render-sha` models. I changed ChatGPT models to be a list of model name (same as OpenAI api). On the API side, you'll also need to change that to a list of model names.

I thought about fetching available model names from ChatGPT directly, but that seems to break the current layered design.