### PR TITLE
Using google search result to improve answer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "react-markdown": "^8.0.4",
         "rehype-highlight": "^6.0.0",
         "swr": "^2.0.0",
+        "turndown": "^7.1.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/lodash-es": "^4.17.6",
+        "@types/turndown": "^5.0.1",
         "@types/uuid": "^9.0.0",
         "@types/webextension-polyfill": "^0.9.2",
         "@typescript-eslint/eslint-plugin": "^5.47.0",
@@ -646,6 +648,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
+      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -1929,6 +1937,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/dotenv": {
       "version": "16.0.3",
@@ -5981,6 +5994,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/turndown": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
+      "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
+      "dependencies": {
+        "domino": "^2.1.6"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6916,6 +6937,12 @@
         "@types/node": "*"
       }
     },
+    "@types/turndown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
+      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==",
+      "dev": true
+    },
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -7798,6 +7825,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "dotenv": {
       "version": "16.0.3",
@@ -10579,6 +10611,14 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "turndown": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
+      "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
+      "requires": {
+        "domino": "^2.1.6"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "react-markdown": "^8.0.4",
     "rehype-highlight": "^6.0.0",
     "swr": "^2.0.0",
+    "turndown": "^7.1.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/lodash-es": "^4.17.6",
+    "@types/turndown": "^5.0.1",
     "@types/uuid": "^9.0.0",
     "@types/webextension-polyfill": "^0.9.2",
     "@typescript-eslint/eslint-plugin": "^5.47.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ const userConfigWithDefaultValue = {
   triggerMode: TriggerMode.Always,
   theme: Theme.Auto,
   language: Language.Auto,
+  googleSearch: true,
 }
 
 export type UserConfig = typeof userConfigWithDefaultValue

--- a/src/content-script/index.tsx
+++ b/src/content-script/index.tsx
@@ -5,7 +5,7 @@ import { detectSystemColorScheme } from '../utils'
 import ChatGPTContainer from './ChatGPTContainer'
 import { config, SearchEngine } from './search-engine-configs'
 import './styles.scss'
-import { getPossibleElementByQuerySelector } from './utils'
+import { getGoogleSearchResult, getPossibleElementByQuerySelector } from './utils'
 
 async function mount(question: string, siteConfig: SearchEngine) {
   const container = document.createElement('div')
@@ -50,11 +50,17 @@ async function run() {
   if (searchInput && searchInput.value) {
     console.debug('Mount ChatGPT on', siteName)
     const userConfig = await getUserConfig()
-    const searchValueWithLanguageOption =
+    let question = searchInput.value
+
+    if (userConfig.googleSearch) {
+      question = (await getGoogleSearchResult(question)) + `\n\nQuestion:\n """${question}"""`
+    }
+
+    question =
       userConfig.language === Language.Auto
-        ? searchInput.value
-        : `${searchInput.value}(in ${userConfig.language})`
-    mount(searchValueWithLanguageOption, siteConfig)
+        ? question
+        : `Answer the question in ${userConfig.language}:\n\n ${question}`
+    mount(question, siteConfig)
   }
 }
 

--- a/src/content-script/utils.ts
+++ b/src/content-script/utils.ts
@@ -1,3 +1,4 @@
+import TurndownService from 'turndown'
 import Browser from 'webextension-polyfill'
 
 export function getPossibleElementByQuerySelector<T extends Element>(
@@ -31,4 +32,32 @@ export async function shouldShowRatingTip() {
   }
   await Browser.storage.local.set({ ratingTipShowTimes: ratingTipShowTimes + 1 })
   return ratingTipShowTimes >= 2
+}
+
+export async function getGoogleSearchResult(question: string) {
+  let searchWithGoogle = ''
+  const googleUrl = `https://www.google.com/search?q=${question}`
+
+  try {
+    const response = await fetch(googleUrl)
+    const html = await response.text()
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(html, 'text/html')
+    const resultDivs = doc.querySelectorAll('div.kvH3mc.BToiNc.UK95Uc')
+    const turndownService = new TurndownService()
+    const results = Array.from(resultDivs).map((resultDiv) =>
+      turndownService.turndown(resultDiv.innerHTML),
+    )
+    console.log(results)
+    searchWithGoogle = `
+      Use your knowledge and Web search to answer the question.
+
+      Web search results:
+      ${results.join('\n')}
+    `
+  } catch (error) {
+    console.log(error)
+  }
+
+  return searchWithGoogle
 }

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,4 +1,5 @@
 import { CssBaseline, GeistProvider, Radio, Select, Text, Toggle, useToasts } from '@geist-ui/core'
+import { ToggleEvent } from '@geist-ui/core/esm/toggle'
 import { capitalize } from 'lodash-es'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import '../base.css'
@@ -47,6 +48,15 @@ function OptionsPage(props: { theme: Theme; onThemeChange: (theme: Theme) => voi
   const onLanguageChange = useCallback(
     (language: Language) => {
       updateUserConfig({ language })
+      setToast({ text: 'Changes saved', type: 'success' })
+    },
+    [setToast],
+  )
+
+  const onGoogleSearchChange = useCallback(
+    (event: ToggleEvent) => {
+      const googleSearch = event.target.checked
+      updateUserConfig({ googleSearch })
       setToast({ text: 'Changes saved', type: 'success' })
     },
     [setToast],
@@ -130,6 +140,15 @@ function OptionsPage(props: { theme: Theme; onThemeChange: (theme: Theme) => voi
             </Select.Option>
           ))}
         </Select>
+        <Text h3 className="mt-8">
+          Allow Google Results for ChatGPT
+        </Text>
+        <div className="flex flex-row items-center gap-4">
+          <Toggle initialChecked onChange={onGoogleSearchChange} />
+          <Text b margin={0}>
+            Allow ChatGPT to access some Google search data and have more up-to-date answers.
+          </Text>
+        </div>
         <Text h3 className="mt-5 mb-0">
           AI Provider
         </Text>


### PR DESCRIPTION
I made a modification to the extension by adding extra data to ChatGPT's prompt. Basically, I make a request to Google with the typed question, get the HTML of the search, and convert the important parts into Markdown to facilitate ChatGPT's understanding. This way, the answers will be more up-to-date since the model was only trained with data up to 2021. Below is an example with the feature turned off and on.

Not using Google search data:
![off](https://user-images.githubusercontent.com/54721131/221437597-60c59b19-1519-437e-8f73-85280df67ba1.png)

Using extra data:
![on](https://user-images.githubusercontent.com/54721131/221437626-e4a9c925-72c7-426e-a9bb-d27e91910925.png)

A video showing how to use this feature:

https://user-images.githubusercontent.com/54721131/221437945-b34c69e3-6f53-4669-a459-56b4c0655c48.mov

