### PR TITLE
Fix:Incorrect file extension

### DIFF
--- a/src/background/fetch-sse.ts
+++ b/src/background/fetch-sse.ts
@@ -1,6 +1,6 @@
 import { createParser } from 'eventsource-parser'
 import { isEmpty } from 'lodash-es'
-import { streamAsyncIterable } from './stream-async-iterable.js'
+import { streamAsyncIterable } from './stream-async-iterable'
 
 export async function fetchSSE(
   resource: string,


### PR DESCRIPTION
While the extension of the stream-async-iterable file was `.ts`, I saw that it was called as `import { streamAsyncIterable } from './stream-async-iterable.js'` when calling it in `fetch-sse.ts`, I wanted to fix it, thank you.